### PR TITLE
send the end-of-message string also after the hello

### DIFF
--- a/lib/net/netconf/transport.rb
+++ b/lib/net/netconf/transport.rb
@@ -70,6 +70,7 @@ module Netconf
     
     def trans_send_hello
       trans_send( Netconf::RPC::MSG_HELLO )
+      trans_send( RPC::MSG_END )
     end
     
     def has_capability?( capability )


### PR DESCRIPTION
to be RFC compliant (https://tools.ietf.org/html/rfc4742#section-3.1),
there has to be a `]]>]]>` after the `<hello/>` part:

```
As the previous example illustrates, a special character sequence,
]]>]]>, MUST be sent by both the client and the server after each XML
document in the NETCONF exchange.
```
