### PR TITLE
Correct error message

### DIFF
--- a/lib/net/netconf/rpc_std.rb
+++ b/lib/net/netconf/rpc_std.rb
@@ -9,7 +9,7 @@ module Netconf
   <capabilities>
     <capability>urn:ietf:params:netconf:base:1.0</capability>
   </capabilities>
-</hello>
+</hello>]]>]]>
 EOM
 
   module Standard


### PR DESCRIPTION
From RFC6242 chapter 4.1 Framing Protocol: The <hello> message MUST be followed by the character sequence ]]>]]>.  Upon reception of the <hello> message, the receiving peer's SSH Transport layer conceptually passes the <hello> message to the Messages layer.  If the :base:1.1 capability is advertised by both peers, the chunked framing mechanism (see Section 4.2) is used for the remainder of the NETCONF session.  Otherwise, the old end-of-message-based mechanism (see Section 4.3) is used.

In the original implementation the client <hello> message is followed by the <rpc> without separator character sequence which is required by the RFC. Therefore the original implementation is NOT standard conform and is causing errors with server implementations enforcing the correct message sequencing. As it seems, JNPR is quite relaxed about the <hello> message while other vendors are more strict.
