### PR TITLE
 Added "require /net/netconf/jnpr/rpc"

### DIFF
--- a/lib/net/netconf/rpc.rb
+++ b/lib/net/netconf/rpc.rb
@@ -1,4 +1,5 @@
 require 'net/netconf/rpc_std'
+require 'net/netconf/jnpr/rpc'
 
 module Netconf  
   module RPC    


### PR DESCRIPTION
Added "require /net/netconf/jnpr/rpc" Added "require /net/netconf/jnpr/rpc"

For fixing below error:

Netconf::RpcError: RPC command error: load-configuration
<rpc-reply xmlns:junos="http://xml.juniper.net/junos/14.2R4/junos"
xmlns="urn:ietf:params:xml:ns:netconf:base:1.0" message-id="2">
<load-configuration-results>
<rpc-error>
<error-type>protocol</error-type>
<error-tag>operation-failed</error-tag>
<error-severity>error</error-severity>
<error-message>syntax error, expecting &lt;configuration&gt; or
&lt;configuration-text&gt;</error-message>
<error-info>
<bad-element>set</bad-element>
</error-info>
</rpc-error>
<load-error-count>1</load-error-count>
</load-configuration-results>
</rpc-reply>
from
/ghome/tgdflto1/rails_projects/safe4/.bundle/ruby/2.2.0/gems/netconf-0.3
.1/lib/net/netconf/transport.rb:141:in `rpc_exec’
