### PR TITLE
Fixes #51

### DIFF
--- a/lib/net/netconf/rpc_std.rb
+++ b/lib/net/netconf/rpc_std.rb
@@ -5,11 +5,13 @@ module Netconf
     MSG_END_RE = /\]\]>\]\]>[\r\n]*$/
     MSG_CLOSE_SESSION = '<rpc><close-session/></rpc>'       
     MSG_HELLO = <<-EOM
+<?xml version="1.0"?>
 <hello xmlns="urn:ietf:params:xml:ns:netconf:base:1.0">
   <capabilities>
     <capability>urn:ietf:params:netconf:base:1.0</capability>
   </capabilities>
 </hello>
+]]>]]>
 EOM
 
   module Standard

--- a/lib/net/netconf/transport.rb
+++ b/lib/net/netconf/transport.rb
@@ -105,7 +105,7 @@ module Netconf
       # receive the response; then covert it to a Nokogiri XML
       # object so we can process it.
       
-      rsp_nx = Nokogiri::XML( send_and_receive( cmd_nx.to_xml ))
+      rsp_nx = Nokogiri::XML( send_and_receive( cmd_nx.parent.to_xml ))
       
       # the following removes only the default namespace (xmlns)
       # definitions from the document.  This is an alternative


### PR DESCRIPTION
Fixes #51 

Not really proposing this, as it's just hack rather than fix. There is no reason ```#root``` is being called and then ```#parent``` later. It should be correct net-netconf specific decorator object.

