### PR TITLE
Update netconf net-ssh and net-scp dependencies

### DIFF
--- a/netconf.gemspec
+++ b/netconf.gemspec
@@ -14,8 +14,8 @@ Gem::Specification.new do |s|
   s.files = FileList['lib/net/**/*.rb', 'examples/**/*.rb']
   s.required_ruby_version = '>= 2.1.0'
   s.add_runtime_dependency('nokogiri', '~> 1.7')
-  s.add_runtime_dependency('net-ssh', '~> 4.1')
-  s.add_runtime_dependency('net-scp', '~> 1.2')
+  s.add_runtime_dependency('net-ssh', '>= 2.6.5', '< 8.0.0')
+  s.add_runtime_dependency('net-scp', '~> 4.0')
   s.add_development_dependency('rake', '~> 12.0')
   s.add_development_dependency('simplecov', '~> 0.14')
   s.add_development_dependency('codeclimate-test-reporter', '~> 1.0')


### PR DESCRIPTION
- Using the old net-ssh version will lead to an ssh key exchange error. This is a known issue in net-ssh
  and fixed in a newer version.